### PR TITLE
Remove sim_params struct and add compute_params

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -18,8 +18,26 @@ git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 version = "1.3.0"
 
+[[AssetRegistry]]
+deps = ["Distributed", "JSON", "Pidfile", "SHA", "Test"]
+git-tree-sha1 = "b25e88db7944f98789130d7b503276bc34bc098e"
+uuid = "bf4720bc-e11a-5d0c-854e-bdca1663c893"
+version = "0.1.0"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinDeps]]
+deps = ["Libdl", "Pkg", "SHA", "URIParser", "Unicode"]
+git-tree-sha1 = "46cf2c1668ad07aba5a9d331bdeea994a1f13856"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "1.0.1"
+
+[[Blink]]
+deps = ["Base64", "BinDeps", "Distributed", "JSExpr", "JSON", "Lazy", "Logging", "MacroTools", "Mustache", "Mux", "Reexport", "Sockets", "WebIO", "WebSockets"]
+git-tree-sha1 = "434893c1f9e9ce59be3f114641e99ef84c4d8f1a"
+uuid = "ad839575-38b3-5650-b840-f874b8c74a25"
+version = "0.12.3"
 
 [[Bzip2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -85,6 +103,12 @@ uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
+[[DocStringExtensions]]
+deps = ["LibGit2", "Markdown", "Pkg", "Test"]
+git-tree-sha1 = "50ddf44c53698f5e784bbebb3f4b21c5807401b1"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.3"
+
 [[EarCut_jll]]
 deps = ["Libdl", "Pkg"]
 git-tree-sha1 = "eabac56550a7d7e0be499125673fbff560eb8b20"
@@ -110,10 +134,13 @@ uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 version = "1.2.4"
 
 [[FFTW_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "6c975cd606128d45d1df432fb812d6eb10fee00b"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "f10c3009373a2d5c4349b8a2932d8accb892892d"
 uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
-version = "3.3.9+5"
+version = "3.3.9+6"
+
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[FixedPointNumbers]]
 deps = ["Statistics"]
@@ -138,6 +165,12 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "0d20aed5b14dd4c9a2453c1b601d08e1149679cc"
 uuid = "559328eb-81f9-559d-9380-de523a88c83c"
 version = "1.0.5+6"
+
+[[FunctionalCollections]]
+deps = ["Test"]
+git-tree-sha1 = "04cb9cfaa6ba5311973994fe3496ddec19b6292a"
+uuid = "de31a74c-ac4f-5751-b3fd-e18cd04993ca"
+version = "0.5.0"
 
 [[GR]]
 deps = ["Base64", "DelimitedFiles", "HTTP", "JSON", "LinearAlgebra", "Printf", "Random", "Serialization", "Sockets", "Test", "UUIDs"]
@@ -167,6 +200,12 @@ deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
 git-tree-sha1 = "c7ec02c4c6a039a98a15f955462cd7aea5df4508"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 version = "0.8.19"
+
+[[Hiccup]]
+deps = ["MacroTools", "Test"]
+git-tree-sha1 = "6187bb2d5fcbb2007c39e7ac53308b0d371124bd"
+uuid = "9fb69e20-1954-56bb-a84f-559cc56a8ff7"
+version = "0.2.2"
 
 [[IniFile]]
 deps = ["Test"]
@@ -199,6 +238,12 @@ git-tree-sha1 = "7cec881362e5b4e367ff0279dd99a06526d51a55"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.1.2"
 
+[[JSExpr]]
+deps = ["JSON", "MacroTools", "Observables", "WebIO"]
+git-tree-sha1 = "829f37792c9a63904a95c3c579e3b5847b40802a"
+uuid = "97c1335a-c9c5-57fe-bc5d-ec35cebe8660"
+version = "0.5.2"
+
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
 git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
@@ -221,6 +266,12 @@ deps = ["Formatting", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdow
 git-tree-sha1 = "829b033e31573b8ffdd14e0d47154fd3ddc7abbf"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 version = "0.14.0"
+
+[[Lazy]]
+deps = ["MacroTools"]
+git-tree-sha1 = "1370f8202dac30758f3c345f9909b97f53d87d3f"
+uuid = "50d2b5c4-7a5e-59d5-8109-a42b560f39c0"
+version = "0.15.1"
 
 [[LibGit2]]
 deps = ["Printf"]
@@ -284,10 +335,27 @@ version = "0.4.4"
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[Mustache]]
+deps = ["Printf", "Tables"]
+git-tree-sha1 = "627ad7585b8c6ae62bc2a0e27debfc95059dcafd"
+uuid = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
+version = "1.0.6"
+
+[[Mux]]
+deps = ["AssetRegistry", "Base64", "HTTP", "Hiccup", "Lazy", "Pkg", "Sockets", "WebSockets"]
+git-tree-sha1 = "8e917fbe96da22628feae3f01b4f100e709ab746"
+uuid = "a975b10e-0019-58db-a62f-e48ff68538c9"
+version = "0.7.3"
+
 [[NaNMath]]
 git-tree-sha1 = "c84c576296d0e2fbb3fc134d3e09086b3ea617cd"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 version = "0.3.4"
+
+[[Observables]]
+git-tree-sha1 = "635fe10760447cfa86f5118edf2f47eb864fb495"
+uuid = "510215fc-4207-5dde-b226-833fc4488ee2"
+version = "0.3.2"
 
 [[Ogg_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -318,6 +386,12 @@ git-tree-sha1 = "6fa4202675c05ba0f8268a6ddf07606350eda3ce"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "1.0.11"
 
+[[Pidfile]]
+deps = ["FileWatching", "Test"]
+git-tree-sha1 = "1be8660b2064893cd2dae4bd004b589278e4440d"
+uuid = "fa939f87-e72e-5be4-a000-7fc836dbe307"
+version = "1.2.0"
+
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
@@ -333,6 +407,18 @@ deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "Stat
 git-tree-sha1 = "4e098f88dad9a2b518b83124a116be1c49e2b2bf"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
 version = "1.0.7"
+
+[[PlotlyBase]]
+deps = ["Base64", "Dates", "DelimitedFiles", "DocStringExtensions", "JSON", "LaTeXStrings", "Logging", "Pkg", "Requires", "Statistics", "UUIDs"]
+git-tree-sha1 = "b33809ab5a35bf41d1fd7c851b52e32004392933"
+uuid = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
+version = "0.4.1"
+
+[[PlotlyJS]]
+deps = ["Blink", "DelimitedFiles", "JSExpr", "JSON", "Markdown", "Pkg", "PlotlyBase", "REPL", "Reexport", "Requires", "WebIO"]
+git-tree-sha1 = "d55517585b572623b61857dadf74e6f53812c2fb"
+uuid = "f0f68f2c-4968-5e81-91da-67840de0976a"
+version = "0.14.0"
 
 [[Plots]]
 deps = ["Base64", "Contour", "Dates", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "GeometryTypes", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs"]
@@ -448,6 +534,12 @@ version = "1.1.0"
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[[URIParser]]
+deps = ["Unicode"]
+git-tree-sha1 = "53a9f49546b8d2dd2e688d216421d050c9a31d0d"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.1"
+
 [[UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
@@ -455,11 +547,29 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
+[[WebIO]]
+deps = ["AssetRegistry", "Base64", "Distributed", "FunctionalCollections", "JSON", "Logging", "Observables", "Pkg", "Random", "Requires", "Sockets", "UUIDs", "WebSockets", "Widgets"]
+git-tree-sha1 = "adc25e225bc334c7df6eec3b39496edfc451cc38"
+uuid = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
+version = "0.8.15"
+
+[[WebSockets]]
+deps = ["Base64", "Dates", "Distributed", "HTTP", "Logging", "Random", "Sockets", "Test"]
+git-tree-sha1 = "13f763d38c7a05688938808b49cb29b18b60c8c8"
+uuid = "104b5d7c-a370-577a-8038-80a2059c5097"
+version = "1.5.2"
+
+[[Widgets]]
+deps = ["Colors", "Dates", "Observables", "OrderedCollections"]
+git-tree-sha1 = "fc0feda91b3fef7fe6948ee09bb628f882b49ca4"
+uuid = "cc8bc4a8-27d6-5769-a93b-9d913e69aa62"
+version = "0.6.2"
+
 [[Zlib_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "ded43825988ace7a311ee7e1d0f09571822509c4"
+git-tree-sha1 = "320228915c8debb12cb434c59057290f0834dbf6"
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.11+17"
+version = "1.2.11+18"
 
 [[libass_jll]]
 deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 

--- a/src/Plotter.jl
+++ b/src/Plotter.jl
@@ -1,7 +1,6 @@
 module Plotter
 using ..Simulation
-using Plots; gr()
-Plots.GRBackend()
+using Plots; gr() 
 using LaTeXStrings
 using FFTW
 
@@ -81,7 +80,7 @@ function plot_ψ(sim::Sim; mode = "density", power=1, x_res=500, t_res=512)
     # Adjust Attributes
     xlabel!(L"x")
     ylabel!(L"t")
-    xlims!((-sim.params.T/2*sim.box.n_periods, sim.params.T/2*sim.box.n_periods))
+    xlims!((-sim.T/2*sim.box.n_periods, sim.T/2*sim.box.n_periods))
     ylims!((minimum(sim.box.x), maximum(sim.box.x)))
 
     println("Plotting done!")
@@ -125,7 +124,7 @@ function plot_ψ̃(sim::Sim; mode = "density", x_res=500, ω_res=512, skip = 1, 
         p = heatmap(ω, x, log.(abs.(ψ̃)), tick_direction=:out, colorbar_title=L"\log|\tilde{\psi}|")
         xlabel!(L"\omega")
         ylabel!(L"x")
-        xlims!((-sim.box.Nₜ/2*sim.params.Ω/sim.box.n_periods, sim.box.Nₜ/2*sim.params.Ω/sim.box.n_periods))
+        xlims!((-sim.box.Nₜ/2*sim.Ω/sim.box.n_periods, sim.box.Nₜ/2*sim.Ω/sim.box.n_periods))
         ylims!((minimum(sim.box.x), maximum(sim.box.x)))
     elseif mode == "lines"
         ψ̃ = ifftshift(sim.ψ̃, 2)[1:xₛ:end, 1:skip:skip*n_lines]

--- a/src/SimTypes.jl
+++ b/src/SimTypes.jl
@@ -1,8 +1,8 @@
 #export SimulationParameters, SimulationBox, Simulation 
-export init_sim_box, init_sim_params, init_sim
+export init_box, init_sim, compute_parameters
 export Sim, SimBox, SimParameters
 
-struct SimBox
+struct Box
     t::Array{Float64, 1}
     ω::Array{Float64, 1}
     x::Array{Float64, 1}
@@ -13,16 +13,11 @@ struct SimBox
     n_periods::Int
 end #SimulationBox
 
-struct SimParameters
-    λ::Complex{Float64}
-    Ω::Float64
-    a::Float64
-    T::Float64
-end #SimParameters
-
 mutable struct Sim
-    box::SimBox
-    params::SimParameters
+    λ::Complex{Float64}
+    T::Float64
+    Ω::Float64
+    box::Box
     ψ₀::Array{Complex{Float64}, 1}
     algorithm::String
     αₚ::Float64
@@ -39,59 +34,49 @@ mutable struct Sim
     P::Array{Float64, 1}
 end # Simulation
 
-function init_sim_params(; kwargs...)
-    println("==========================================")
-    println("Initializing simulation parameters.")
+function compute_parameters(; kwargs...)
     if length(kwargs) != 1
-        throw(ArgumentError("You have either specified too few or too many parameters. You must specify one and only one of the following options: Ω, T, a, λ."))
+        throw(ArgumentError("You have either specified too few or too many parameters. You must specify one and only one of the following options: λ, Ω, T, a."))
     end
     param = Dict(kwargs)
     if :a in keys(param)
-        a = param[:a]
-        println("Passed auxillary eigenvalue a = $a")
-        λ = im * sqrt(2 * a)
-        Ω = 2 * sqrt(1 - 2 * a)
-        T = 2π / Ω
-    elseif :λ in keys(param)
+        λ = im * sqrt(2 * param[:a])
+        T = π/sqrt(1 - imag(λ)^2)
+        Ω = 2π/T
+        println("Passed a = $(param[:a]), computed λ = $λ, T = $T and Ω = $Ω")
+    elseif :λ  in keys(param)
         λ = param[:λ]
-        println("Passed eigenvalue λ=$λ")
-        a = imag(λ)^2 / 2
-        Ω = 2 * sqrt(1 - 2 * a)
-        T = 2π / Ω
+        T = π/sqrt(1 - imag(λ)^2)
+        Ω = 2π/T
+        println("Passed λ=$λ, computed T = $T and Ω = $Ω")
     elseif :Ω in keys(param)
+        λ = im * sqrt((1 - (param[:Ω] / 2)^2))
+        T = π/sqrt(1 - imag(λ)^2)
         Ω = param[:Ω]
-        println("Passed frequency Ω=$Ω")
-        a = (1 - (Ω / 2)^2) / 2
-        λ = im * sqrt(2 * a)
-        T = 2π / Ω
+        println("Passed Ω=$Ω, computed λ = $λ and T = $T")
     elseif :T in keys(param)
+        λ = im * sqrt((1 - ((2*π/param[:T]) / 2)^2))
         T = param[:T]
-        println("Passed period T = $T")
-        Ω = 2π / T
-        a = (1 - (Ω / 2)^2) / 2
-        λ = im * sqrt(2 * a)
+        Ω = 2π/T
+        println("Passed T = $T, computed λ = $λ and Ω = $Ω")
     end
-    params = SimParameters(λ, Ω, a, T)
 
-    println("Calculated Result: a = $a, λ = $λ, Ω = $Ω, T =$T")
-    println("==========================================")
+    return λ, T, Ω
+end #compute_parameters
 
-    return params
-end #init_sim_params
-
-function init_sim_box(xᵣ::Pair, params::SimParameters; dx = 1e-3, Nₜ = 256, n_periods::Int = 1)
+function init_box(xᵣ::Pair, T::Float64; dx = 1e-3, Nₜ = 256, n_periods = 1)
     println("==========================================")
     println("Initializing simulation box with $n_periods period(s) and dx = $dx, Nₜ = $Nₜ.")
-    println("Box range is [xᵣ.first, xᵣ.second]")
-    T = n_periods * params.T
+    T = n_periods * T
+    println("Longitudinal range is [$(xᵣ.first), $(xᵣ.second)], transverse range is [$(-T/2), $(T/2))")
     dt = T / Nₜ
     t = dt * (-Nₜ/2:Nₜ/2-1)
 
     x = xᵣ.first:dx:xᵣ.second
     Nₓ = length(x)
-    ω = 2 * π / T * (-Nₜ/2:Nₜ/2-1)
+    ω = 2π/T * (-Nₜ/2:Nₜ/2-1)
 
-    box = SimBox(t, ω, x, Nₜ, Nₓ, dt, dx, n_periods)
+    box = Box(t, ω, x, Nₜ, Nₓ, dt, dx, n_periods)
 
     println("Done computing t, x, ω")
     println("==========================================")
@@ -99,7 +84,7 @@ function init_sim_box(xᵣ::Pair, params::SimParameters; dx = 1e-3, Nₜ = 256, 
     return box
 end
 
-function init_sim(box::SimBox, params::SimParameters, ψ₀::Array; algorithm = "2S", αₚ = 0)
+function init_sim(λ, box::Box, ψ₀::Array; algorithm = "2S", αₚ = 0)
     ψ = Array{Complex{Float64}}(undef, box.Nₓ, box.Nₜ)
     ψ̃ = similar(ψ)
     E = zeros(box.Nₓ)
@@ -114,7 +99,9 @@ function init_sim(box::SimBox, params::SimParameters, ψ₀::Array; algorithm = 
     if αₚ > 0 && box.n_periods == 1 
         throw(ArgumentError("Pruning is only applicable when n_periods > 1."))
     end
-    #set_num_threads(1)
-    sim = Sim(box, params, ψ₀, algorithm, αₚ, false, ψ, false, ψ̃, false, E, PE, KE, dE, N, P)
+    # Compute some parameters
+    λ, T, Ω = compute_parameters(λ = λ)
+    sim = Sim(λ, T, Ω, box, ψ₀, algorithm, αₚ, false, ψ, false, ψ̃, false, E, PE, KE, dE, 
+    N, P)
    return sim
 end #init_sim

--- a/src/SimUtilities.jl
+++ b/src/SimUtilities.jl
@@ -12,10 +12,9 @@ function print(sim::Sim)
     println("Nₜ = $(sim.box.dx) (dt = $(sim.box.dt))")
     println("Parameters:")
     println("------------------------------------------")
-    println("a = $(sim.params.a)")
-    println("λ = $(sim.params.λ)")
-    println("Ω = $(sim.params.Ω)")
-    println("T = $(sim.params.T)")
+    println("λ = $(sim.λ)")
+    println("Ω = $(sim.Ω)")
+    println("T = $(sim.T)")
     println("------------------------------------------")
     # Should add information about ψ₀
     if sim.algorithm == "2S"
@@ -91,7 +90,7 @@ and coefficients ``A_1...n`` = `coeff` and an overall phase `exp(i phase t)`, i.
 
 See also: [`init_sim`](@ref)
 """
-function ψ₀_periodic(coeff, box::SimBox, params::SimParameters; phase=0)
+function ψ₀_periodic(coeff, box::Box, Ω; phase=0)
     println("==========================================")
     println("Initializing periodic ψ₀")
     for (n, An) in enumerate(coeff)
@@ -114,8 +113,8 @@ function ψ₀_periodic(coeff, box::SimBox, params::SimParameters; phase=0)
 
     ψ₀ = A0 * ones(box.Nₜ)
     for (n, An) in enumerate(coeff)
-        ψ₀ += 2 * An * cos.(n * params.Ω * box.t)
-        str = string(str, "2 × $An × cos($n × $(params.Ω) t)")
+        ψ₀ += 2 * An * cos.(n * Ω * box.t)
+        str = string(str, "2 × $An × cos($n × $(Ω) t)")
     end #for
     # Multiply by the overall phase
     ψ₀ = exp.(im * phase * box.t) .* ψ₀


### PR DESCRIPTION
This pull request cleans up the interface to make it more applicable for DT calculations. Now the `SimBox` object is renamed to box and does not have to be a periodic size to allow for usage with DT calculations (this restriction is arbitrary, nothing is stopping you from using a wave function in the wrong size periodic box, you'll just get garbage results).

The workflow at the moment is as follows:

```
using NLSS

λ, T, Ω = NLSS.Simulation.compute_parameters(T = 20.0)

xᵣ = 0=>20
box = NLSS.Simulation.init_box(xᵣ, T, dx=1e-3, Nₜ = 512, n_periods = 1)
coeff = [1e-4]
ψ₀ = NLSS.Simulation.ψ₀_periodic(coeff, box, Ω)

sim = NLSS.Simulation.init_sim(λ, box, ψ₀, algorithm = "2S", αₚ = 0)

NLSS.Simulation.solve!(sim)
```